### PR TITLE
OnItemSelected listener reflects newly focused item

### DIFF
--- a/HorizontalPicker/src/main/java/com/wefika/horizontalpicker/HorizontalPicker.java
+++ b/HorizontalPicker/src/main/java/com/wefika/horizontalpicker/HorizontalPicker.java
@@ -564,9 +564,7 @@ public class HorizontalPicker extends View {
     }
 
     private void selectItem() {
-        if (mOnItemSelected != null) {
-            mOnItemSelected.onItemSelected(getSelectedItem());
-        }
+
         if (mOnItemClicked != null) {
             mOnItemClicked.onItemClicked(getSelectedItem());
         }


### PR DESCRIPTION
I found that the OnItemSelected listener was only updated when the user tapped on a value after it was already in focus (centered in the picker). When you scroll/fling the picker, onItemSelected is now called when a value is landed on, without the user having to select it explicitly after it's already been focused.
