### PR TITLE
Issue#14: Fix invisibility issue with older OS versions

### DIFF
--- a/HorizontalPicker/src/main/java/com/wefika/horizontalpicker/HorizontalPicker.java
+++ b/HorizontalPicker/src/main/java/com/wefika/horizontalpicker/HorizontalPicker.java
@@ -564,9 +564,14 @@ public class HorizontalPicker extends View {
     }
 
     private void selectItem() {
-
+        // post to the UI Thread to avoid potential interference with the OpenGL Thread
         if (mOnItemClicked != null) {
-            mOnItemClicked.onItemClicked(getSelectedItem());
+            post(new Runnable() {
+                @Override
+                public void run() {
+                    mOnItemClicked.onItemClicked(getSelectedItem());
+                }
+            });
         }
 
         adjustToNearestItemX();
@@ -870,12 +875,16 @@ public class HorizontalPicker extends View {
 
         adjustToNearestItemX();
         mScrollingX = false;
-
-        if (mOnItemSelected != null) {
-            mOnItemSelected.onItemSelected(getPositionFromCoordinates(getScrollX()));
-        }
-
         startMarqueeIfNeeded();
+        // post to the UI Thread to avoid potential interference with the OpenGL Thread
+        if (mOnItemSelected != null) {
+            post(new Runnable() {
+                @Override
+                public void run() {
+                    mOnItemSelected.onItemSelected(getPositionFromCoordinates(getScrollX()));
+                }
+            });
+        }
     }
 
     private void startMarqueeIfNeeded() {
@@ -970,7 +979,7 @@ public class HorizontalPicker extends View {
      */
     private void scrollToItem(int index) {
         scrollTo((mItemWidth + (int) mDividerSize) * index, 0);
-        invalidate();
+        // invalidate() not needed because scrollTo() already invalidates the view
     }
 
     /**


### PR DESCRIPTION
onItemClicked() listener and onItemSelected() listener could be doing many things such as updating another view on the same canvas. This could potentially interfere with any ongoing canvas.draw() method in HorizontalPicker.onDraw() for older OS versions.  So, post the listener to be run in the UI Thread to avoid interfering with the OpenGL Thread.

Fixes issue #14 